### PR TITLE
Pass the filename to the autocomplete command

### DIFF
--- a/rplugin/python3/deoplete/sources/flow.py
+++ b/rplugin/python3/deoplete/sources/flow.py
@@ -11,13 +11,14 @@ log = getLogger('logging')
 CONFIG_FILE = '.flowconfig'
 
 def find_config_directory(root):
-    for files in os.listdir(root):
-        if CONFIG_FILE in files:
-            return root
-        elif root == '/':
-            return None
-        else:
-            return find_config_directory(os.path.dirname(root))
+    log.debug('Searching: ' + root);
+
+    if CONFIG_FILE in os.listdir(root):
+        return root
+    elif root == '/':
+        return None
+    else:
+        return find_config_directory(os.path.dirname(root))
 
 class Source(Base):
     def __init__(self, vim):

--- a/rplugin/python3/deoplete/sources/flow.py
+++ b/rplugin/python3/deoplete/sources/flow.py
@@ -40,12 +40,20 @@ class Source(Base):
             current_directory = self.vim.eval("expand('%:p:h')")
             self._project_directory = find_config_directory(current_directory)
 
+        if not self._project_directory:
+            return None
+
         filename = self.vim.eval("expand('%:p')")
 
         return filename[len(self._project_directory) + 1:]
 
     def gather_candidates(self, context):
         file_name = self.relative_file()
+
+        if not file_name:
+            log.debug('No flow config found; skipping');
+            return []
+
         line = str(self.vim.current.window.cursor[0])
         column = str(self.vim.current.window.cursor[1] + 1)
         command = [self.flow_bin, 'autocomplete', '--json', '--no-auto-start', file_name, line, column]


### PR DESCRIPTION
I was having a bunch of trouble getting this plugin to work, and ultimately realized that the issue was the fact that the file name wasn't being passed along. (See https://github.com/facebook/flow/issues/3415)

To fix this, I took a page out of [`deoplete-ternjs`'s book](https://github.com/carlitux/deoplete-ternjs/blob/9eaedeab499e2d0a34fba72afa1ff65d34752cbf/rplugin/python3/deoplete/sources/ternjs.py#L93) and used the config file to find the project root, and then from there get a relative path to the current file. This fixed the issue for me, and I get the correct autocompletion.